### PR TITLE
fix: drop deprecated fastlane error message

### DIFF
--- a/photochatapp/android/fastlane/Fastfile
+++ b/photochatapp/android/fastlane/Fastfile
@@ -13,7 +13,7 @@ platform :android do
         skip_upload_images: true
       )
     rescue => exception
-      raise exception unless exception.message.include?('apkNotificationMessageKeyUpgradeVersionConflict')
+      raise exception unless exception.message.include?('APK specifies a version code that has already been used.')
       puts 'Current version already present on the Play Store. Omitting this upload.'
     end
   end


### PR DESCRIPTION
The previous error message we were looking for has been deprecated and thus we will treat dup uploading apk as an actual error. In this PR, we will use the new error message to reduce noise in CI failure.

<!-- Please make sure to read CONTRIBUTING.md first -->


<a href="https://gitpod.io/#https://github.com/tianhaoz95/photochat/pull/172"><img src="https://gitpod.io/api/apps/github/pbs/github.com/tianhaoz95/photochat.git/2edfbed4ba26697aefececc902932b0df5fb668a.svg" /></a>

